### PR TITLE
from . import functional for line 35 of compat.py

### DIFF
--- a/matchbox/compat.py
+++ b/matchbox/compat.py
@@ -6,6 +6,8 @@
 
 import torch
 
+from . import functional
+
 if torch.__version__ < '0.4':
     MAYBE_VARIABLE = TENSOR_TYPE = torch.autograd.Variable
 


### PR DESCRIPTION
Prior to this change, __functional__ is an undefined name in this context.